### PR TITLE
fix (param_feature): Remove conflict with `use Wallaby.Feature`

### DIFF
--- a/lib/parameterized_test.ex
+++ b/lib/parameterized_test.ex
@@ -165,7 +165,7 @@ defmodule ParameterizedTest do
     """
     defmacro param_feature(test_name, examples, context_ast \\ quote(do: %{}), blocks) do
       quote location: :keep do
-        use Wallaby.Feature
+        require Wallaby.Feature
 
         context =
           __ENV__
@@ -192,7 +192,7 @@ defmodule ParameterizedTest do
           @param_test_context context
 
           @tag param_test: true
-          feature "#{@full_test_name}", unquote(context_ast) do
+          Wallaby.Feature.feature "#{@full_test_name}", unquote(context_ast) do
             try do
               unquote(blocks)
             catch

--- a/test/parameterized_test/backtrace_test.exs
+++ b/test/parameterized_test/backtrace_test.exs
@@ -4,8 +4,8 @@ defmodule ParameterizedTest.BacktraceTest do
   # This is to be expected, and is kind of the price to pay for getting really
   # obviously correct behavior here.
   use ExUnit.Case, async: true
-
   use Wallaby.Feature
+
   import ParameterizedTest
 
   param_test "gives the failing parameter row when a test fails",

--- a/test/parameterized_test/backtrace_test.exs
+++ b/test/parameterized_test/backtrace_test.exs
@@ -5,6 +5,7 @@ defmodule ParameterizedTest.BacktraceTest do
   # obviously correct behavior here.
   use ExUnit.Case, async: true
 
+  use Wallaby.Feature
   import ParameterizedTest
 
   param_test "gives the failing parameter row when a test fails",

--- a/test/parameterized_test_test.exs
+++ b/test/parameterized_test_test.exs
@@ -370,6 +370,7 @@ end
 defmodule ParameterizedTestTest.WallabyTest do
   use ExUnit.Case, async: true
 
+  use Wallaby.Feature
   import ParameterizedTest
 
   param_feature "supports Wallaby tests",

--- a/test/parameterized_test_test.exs
+++ b/test/parameterized_test_test.exs
@@ -369,8 +369,8 @@ end
 
 defmodule ParameterizedTestTest.WallabyTest do
   use ExUnit.Case, async: true
-
   use Wallaby.Feature
+
   import ParameterizedTest
 
   param_feature "supports Wallaby tests",


### PR DESCRIPTION
Replaces `use Wallaby.Feature` with merely invoking the `Wallaby.Feature.feature` macro. This puts the impetus on the calling test to `use Wallaby.Feature` first if they want support for screenshots on failure.

Resolves #81